### PR TITLE
Fix element click hanging indefinitely

### DIFF
--- a/src/fsq_mac/adapters/appium_mac2.py
+++ b/src/fsq_mac/adapters/appium_mac2.py
@@ -244,10 +244,40 @@ class AppiumMac2Adapter:
         self._delay_post_action: float = config.get("delay_post_action", 0)
         self._delay_pre_input: float = config.get("delay_pre_input", 0)
         self._delay_double_click_gap: float = config.get("delay_double_click_gap", 0)
+        # Command timeout — caps any single driver call (find, click, etc.)
+        self._command_timeout: float = config.get("command_timeout", 15.0)
         # Tree cache
         self._tree_cache: str | None = None
         self._tree_cache_time: float = 0.0
         self._tree_ttl: float = config.get("tree_cache_ttl", 2.0)
+
+    def _run_with_timeout(self, fn, timeout: float | None = None):
+        """Run *fn* in a thread; raise TimeoutError if it exceeds *timeout*."""
+        timeout = timeout or self._command_timeout
+        result_box: list = []
+        error_box: list = []
+
+        def _target():
+            try:
+                result_box.append(fn())
+            except Exception as exc:
+                error_box.append(exc)
+
+        t = threading.Thread(target=_target, daemon=True)
+        t.start()
+        t.join(timeout)
+        if t.is_alive():
+            raise TimeoutError(
+                f"Driver operation timed out after {timeout}s"
+            )
+        if error_box:
+            raise error_box[0]
+        return result_box[0] if result_box else None
+
+    def _configure_driver_timeouts(self) -> None:
+        """Set Selenium implicit wait on the current driver."""
+        if self._driver:
+            self._driver.implicitly_wait(self._command_timeout)
 
     def _get_page_source(self, force_refresh: bool = False) -> str:
         """Return page source, using cache if within TTL."""
@@ -275,6 +305,7 @@ class AppiumMac2Adapter:
             caps["bundleId"] = bundle_id
         options = Mac2Options().load_capabilities(caps)
         self._driver = webdriver.Remote(self._server_url, options=options)
+        self._configure_driver_timeouts()
 
     @property
     def connected(self) -> bool:
@@ -398,10 +429,14 @@ class AppiumMac2Adapter:
             return (el, None) if el is not None else (None, ErrorCode.ELEMENT_NOT_FOUND)
         if query.role or query.name:
             try:
-                candidates = self._driver.find_elements(AppiumBy.XPATH, "//*")
+                def _find_by_role_name():
+                    candidates = self._driver.find_elements(AppiumBy.XPATH, "//*")
+                    return [el for el in candidates if self._matches_query(el, query)]
+                matches = self._run_with_timeout(_find_by_role_name)
+            except TimeoutError:
+                return None, ErrorCode.TIMEOUT
             except Exception:
-                candidates = []
-            matches = [el for el in candidates if self._matches_query(el, query)]
+                matches = []
             if not matches:
                 return None, ErrorCode.ELEMENT_NOT_FOUND
             if len(matches) > 1:
@@ -409,10 +444,14 @@ class AppiumMac2Adapter:
             return matches[0], None
         if query.label:
             try:
-                candidates = self._driver.find_elements(AppiumBy.XPATH, "//*")
+                def _find_by_label():
+                    candidates = self._driver.find_elements(AppiumBy.XPATH, "//*")
+                    return [el for el in candidates if self._matches_query(el, query)]
+                matches = self._run_with_timeout(_find_by_label)
+            except TimeoutError:
+                return None, ErrorCode.TIMEOUT
             except Exception:
-                candidates = []
-            matches = [el for el in candidates if self._matches_query(el, query)]
+                matches = []
             if not matches:
                 return None, ErrorCode.ELEMENT_NOT_FOUND
             if len(matches) > 1:
@@ -516,6 +555,7 @@ class AppiumMac2Adapter:
             cfg.pop("server_url", None)
             options = Mac2Options().load_capabilities(cfg)
             self._driver = webdriver.Remote(self._server_url, options=options)
+            self._configure_driver_timeouts()
             self._invalidate_refs()
             self._tree_cache = None
             return self._frontmost_info()
@@ -719,10 +759,16 @@ class AppiumMac2Adapter:
         if wait_error:
             return wait_error
         try:
-            ActionChains(self._driver).move_to_element(el).click().perform()
+            self._run_with_timeout(
+                lambda: ActionChains(self._driver).move_to_element(el).click().perform()
+            )
+        except TimeoutError as exc:
+            return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
         except Exception:
             try:
-                el.click()
+                self._run_with_timeout(lambda: el.click())
+            except TimeoutError as exc:
+                return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
             except Exception as exc:
                 return {"error_code": ErrorCode.ELEMENT_NOT_FOUND, "detail": str(exc)}
         time.sleep(self._delay_post_action)
@@ -738,7 +784,11 @@ class AppiumMac2Adapter:
         if wait_error:
             return wait_error
         try:
-            ActionChains(self._driver).context_click(el).perform()
+            self._run_with_timeout(
+                lambda: ActionChains(self._driver).context_click(el).perform()
+            )
+        except TimeoutError as exc:
+            return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
         except Exception as exc:
             return {"error_code": ErrorCode.ELEMENT_NOT_FOUND, "detail": str(exc)}
         time.sleep(self._delay_post_action)
@@ -754,13 +804,17 @@ class AppiumMac2Adapter:
         if wait_error:
             return wait_error
         try:
-            loc = el.location
-            sz = el.size
-            x = loc["x"] + sz["width"] / 2
-            y = loc["y"] + sz["height"] / 2
-            self._driver.tap([(x, y)])
-            time.sleep(self._delay_double_click_gap)
-            self._driver.tap([(x, y)])
+            def _do_double_click():
+                loc = el.location
+                sz = el.size
+                x = loc["x"] + sz["width"] / 2
+                y = loc["y"] + sz["height"] / 2
+                self._driver.tap([(x, y)])
+                time.sleep(self._delay_double_click_gap)
+                self._driver.tap([(x, y)])
+            self._run_with_timeout(_do_double_click)
+        except TimeoutError as exc:
+            return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
         except Exception as exc:
             return {"error_code": ErrorCode.ELEMENT_NOT_FOUND, "detail": str(exc)}
         time.sleep(self._delay_post_action)
@@ -776,9 +830,13 @@ class AppiumMac2Adapter:
         if wait_error:
             return wait_error
         try:
-            ActionChains(self._driver).move_to_element(el).perform()
+            self._run_with_timeout(
+                lambda: ActionChains(self._driver).move_to_element(el).perform()
+            )
             if duration > 0:
                 time.sleep(duration)
+        except TimeoutError as exc:
+            return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
         except Exception as exc:
             return {"error_code": ErrorCode.ELEMENT_NOT_FOUND, "detail": str(exc)}
         return {}
@@ -791,13 +849,17 @@ class AppiumMac2Adapter:
         if wait_error:
             return wait_error
         try:
-            el.click()
-            el.clear()
-            try:
-                el.send_keys(text)
-            except Exception:
-                # Fallback to macos: keys only when send_keys fails (#9)
-                self._driver.execute_script("macos: keys", {"keys": list(text)})
+            def _do_type():
+                el.click()
+                el.clear()
+                try:
+                    el.send_keys(text)
+                except Exception:
+                    # Fallback to macos: keys only when send_keys fails (#9)
+                    self._driver.execute_script("macos: keys", {"keys": list(text)})
+            self._run_with_timeout(_do_type)
+        except TimeoutError as exc:
+            return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
         except Exception as exc:
             return {"error_code": ErrorCode.ELEMENT_NOT_FOUND, "detail": str(exc)}
         # Verify the typed value
@@ -840,7 +902,11 @@ class AppiumMac2Adapter:
         if wait_error:
             return wait_error
         try:
-            ActionChains(self._driver).drag_and_drop(src, tgt).perform()
+            self._run_with_timeout(
+                lambda: ActionChains(self._driver).drag_and_drop(src, tgt).perform()
+            )
+        except TimeoutError as exc:
+            return {"error_code": ErrorCode.TIMEOUT, "detail": str(exc)}
         except Exception as exc:
             return {"error_code": ErrorCode.ELEMENT_NOT_FOUND, "detail": str(exc)}
         self._invalidate_refs()

--- a/tests/test_command_timeout.py
+++ b/tests/test_command_timeout.py
@@ -1,0 +1,196 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Tests for command timeout (issue #4): prevent driver operations from hanging."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fsq_mac.adapters.appium_mac2 import AppiumMac2Adapter
+from fsq_mac.models import ErrorCode
+
+
+@pytest.fixture()
+def mock_config():
+    return {
+        "server_url": "http://127.0.0.1:4723",
+        "platformName": "mac",
+        "automationName": "Mac2",
+        "bundleId": "com.apple.calculator",
+        "command_timeout": 0.5,  # short timeout for tests
+    }
+
+
+@pytest.fixture()
+def mock_driver():
+    driver = MagicMock()
+    driver.capabilities = {"bundleId": "com.apple.calculator"}
+    driver.get_window_size.return_value = {"width": 400, "height": 600}
+    driver.page_source = "<AppiumAUT><XCUIElementTypeButton name='5'/></AppiumAUT>"
+    return driver
+
+
+@pytest.fixture()
+def adapter(mock_config, mock_driver):
+    a = AppiumMac2Adapter(mock_config)
+    a._driver = mock_driver
+    return a
+
+
+# ---------------------------------------------------------------------------
+# _run_with_timeout unit tests
+# ---------------------------------------------------------------------------
+
+def test_run_with_timeout_returns_result(adapter):
+    """Successful function returns its value."""
+    result = adapter._run_with_timeout(lambda: 42)
+    assert result == 42
+
+
+def test_run_with_timeout_raises_on_timeout(adapter):
+    """Blocking function triggers TimeoutError."""
+    def _block():
+        time.sleep(5)
+    with pytest.raises(TimeoutError, match="timed out after"):
+        adapter._run_with_timeout(_block, timeout=0.1)
+
+
+def test_run_with_timeout_propagates_exception(adapter):
+    """Exception in fn is re-raised by the caller."""
+    def _fail():
+        raise ValueError("boom")
+    with pytest.raises(ValueError, match="boom"):
+        adapter._run_with_timeout(_fail)
+
+
+def test_run_with_timeout_uses_config_default(mock_config, mock_driver):
+    """Timeout defaults to command_timeout from config."""
+    mock_config["command_timeout"] = 0.1
+    a = AppiumMac2Adapter(mock_config)
+    a._driver = mock_driver
+    with pytest.raises(TimeoutError):
+        a._run_with_timeout(lambda: time.sleep(5))
+
+
+# ---------------------------------------------------------------------------
+# click() returns TIMEOUT instead of hanging
+# ---------------------------------------------------------------------------
+
+def _prep_adapter(adapter):
+    """Set up common mocks for action methods."""
+    adapter._invalidate_refs = MagicMock()
+    mock_el = MagicMock()
+    mock_el.location = {"x": 10, "y": 10}
+    mock_el.size = {"width": 20, "height": 20}
+    adapter._resolve_ref = MagicMock(return_value=(mock_el, None))
+    adapter._wait_for_actionable = MagicMock(return_value=None)
+    return mock_el
+
+
+def test_click_returns_timeout_when_action_hangs(adapter):
+    """click() should return TIMEOUT error when ActionChains.perform blocks."""
+    mock_el = _prep_adapter(adapter)
+    with patch("fsq_mac.adapters.appium_mac2.ActionChains") as MockAC:
+        chain = MockAC.return_value.move_to_element.return_value.click.return_value
+        chain.perform.side_effect = lambda: time.sleep(5)
+        # Also make fallback el.click() block
+        mock_el.click.side_effect = lambda: time.sleep(5)
+        result = adapter.click("e0")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+def test_click_fallback_timeout(adapter):
+    """If ActionChains fails with non-timeout, fallback el.click() timeout is caught."""
+    mock_el = _prep_adapter(adapter)
+    with patch("fsq_mac.adapters.appium_mac2.ActionChains") as MockAC:
+        chain = MockAC.return_value.move_to_element.return_value.click.return_value
+        chain.perform.side_effect = RuntimeError("primary failed")
+        mock_el.click.side_effect = lambda: time.sleep(5)
+        result = adapter.click("e0")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+def test_right_click_returns_timeout(adapter):
+    """right_click() should return TIMEOUT when context_click blocks."""
+    _prep_adapter(adapter)
+    with patch("fsq_mac.adapters.appium_mac2.ActionChains") as MockAC:
+        chain = MockAC.return_value.context_click.return_value
+        chain.perform.side_effect = lambda: time.sleep(5)
+        result = adapter.right_click("e0")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+def test_double_click_returns_timeout(adapter):
+    """double_click() should return TIMEOUT when tap operations block."""
+    mock_el = _prep_adapter(adapter)
+    adapter._driver.tap.side_effect = lambda *a, **k: time.sleep(5)
+    result = adapter.double_click("e0")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+def test_hover_returns_timeout(adapter):
+    """hover() should return TIMEOUT when move_to_element blocks."""
+    _prep_adapter(adapter)
+    with patch("fsq_mac.adapters.appium_mac2.ActionChains") as MockAC:
+        chain = MockAC.return_value.move_to_element.return_value
+        chain.perform.side_effect = lambda: time.sleep(5)
+        result = adapter.hover("e0")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+def test_type_text_returns_timeout(adapter):
+    """type_text() should return TIMEOUT when el.click/send_keys blocks."""
+    mock_el = _prep_adapter(adapter)
+    mock_el.click.side_effect = lambda: time.sleep(5)
+    result = adapter.type_text("e0", "hello")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+def test_drag_returns_timeout(adapter):
+    """drag() should return TIMEOUT when drag_and_drop blocks."""
+    adapter._invalidate_refs = MagicMock()
+    src = MagicMock()
+    tgt = MagicMock()
+    adapter._resolve_ref = MagicMock(side_effect=[(src, None), (tgt, None)])
+    adapter._wait_for_actionable = MagicMock(return_value=None)
+    with patch("fsq_mac.adapters.appium_mac2.ActionChains") as MockAC:
+        chain = MockAC.return_value.drag_and_drop.return_value
+        chain.perform.side_effect = lambda: time.sleep(5)
+        result = adapter.drag("e0", "e1")
+    assert result.get("error_code") == ErrorCode.TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# _resolve_query timeout
+# ---------------------------------------------------------------------------
+
+def test_resolve_query_returns_timeout_on_slow_find(mock_config, mock_driver):
+    """_resolve_query returns TIMEOUT when find_elements blocks."""
+    from fsq_mac.models import LocatorQuery
+    mock_config["command_timeout"] = 0.2
+    a = AppiumMac2Adapter(mock_config)
+    a._driver = mock_driver
+    mock_driver.find_elements.side_effect = lambda *a, **k: time.sleep(5)
+    query = LocatorQuery(role="AXButton", name="OK")
+    _, err = a._resolve_query(query)
+    assert err == ErrorCode.TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# configure_driver_timeouts
+# ---------------------------------------------------------------------------
+
+def test_configure_driver_timeouts_sets_implicit_wait(adapter, mock_driver):
+    """_configure_driver_timeouts sets implicitly_wait on the driver."""
+    adapter._configure_driver_timeouts()
+    mock_driver.implicitly_wait.assert_called_once_with(adapter._command_timeout)
+
+
+def test_configure_driver_timeouts_noop_without_driver(mock_config):
+    """_configure_driver_timeouts is a no-op when _driver is None."""
+    a = AppiumMac2Adapter(mock_config)
+    a._configure_driver_timeouts()  # should not raise


### PR DESCRIPTION
## Summary

- Add `_run_with_timeout()` thread-based wrapper with configurable `command_timeout` (default 15s) to cap any single driver call
- Configure Selenium `implicitly_wait` on the WebDriver after creation in both `connect()` and `app_launch()`
- Wrap all action methods that use `ActionChains.perform()` or direct element calls: `click()`, `right_click()`, `double_click()`, `hover()`, `type_text()`, `drag()`
- Wrap `_resolve_query()` element enumeration (`find_elements(XPATH, "//*")` + per-element `get_attribute()`) with timeout
- All timeouts return `ErrorCode.TIMEOUT` with descriptive message instead of hanging

## Test plan

- [x] `test_run_with_timeout_returns_result` — successful fn returns value
- [x] `test_run_with_timeout_raises_on_timeout` — blocking fn triggers TimeoutError
- [x] `test_run_with_timeout_propagates_exception` — fn exception re-raised
- [x] `test_run_with_timeout_uses_config_default` — timeout from config
- [x] `test_click_returns_timeout_when_action_hangs` — click → TIMEOUT
- [x] `test_click_fallback_timeout` — fallback el.click() → TIMEOUT
- [x] `test_right_click_returns_timeout` — right_click → TIMEOUT
- [x] `test_double_click_returns_timeout` — double_click → TIMEOUT
- [x] `test_hover_returns_timeout` — hover → TIMEOUT
- [x] `test_type_text_returns_timeout` — type_text → TIMEOUT
- [x] `test_drag_returns_timeout` — drag → TIMEOUT
- [x] `test_resolve_query_returns_timeout_on_slow_find` — query resolution → TIMEOUT
- [x] `test_configure_driver_timeouts_sets_implicit_wait` — implicit wait configured
- [x] `test_configure_driver_timeouts_noop_without_driver` — no crash when driver is None
- [x] Full suite: 545 tests pass

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)